### PR TITLE
update href links

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,21 +34,12 @@ jobs:
           # empty contents
           rm -f -r ./gh-pages/*
 
-          # install npm dependencies
-          cd ./dist
-          npm install
-          cd ..
-
           # copy back to pages
           cp -f -r ./dist/. ./gh-pages/
 
-          # create localization directories
-          LANGUAGES=("en" "es-ES")
-
-          for LANGUAGE in ${LANGUAGES[*]}; do
-            mkdir -p ./gh-pages/$LANGUAGE
-            cp -f -r ./dist/. ./gh-pages/$LANGUAGE/
-          done
+          # install npm dependencies
+          cd ./gh-pages
+          npm install
 
       - name: Upload Artifacts
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}

--- a/dist/index.html
+++ b/dist/index.html
@@ -328,7 +328,7 @@
                                     – Confucius.
                                 </p>
                                 <div class="input-group mb-2">
-                                    <a href="/support">
+                                    <a href="support">
                                         <button class="btn btn-outline-light rounded-0"
                                                 id="button-support"
                                                 type="button"

--- a/dist/js/crowdin.js
+++ b/dist/js/crowdin.js
@@ -8,7 +8,7 @@ $.getScript('https://proxy-translator.app.crowdin.net/assets/proxy-translator.js
         baseUrl: "https://app.lizardbyte.dev",
         distributionBaseUrl: "https://distributions.crowdin.net",
         filePath: "/app.lizardbyte.dev.json",
-        distribution: "a4655f152d6ea4b5113a0991bw4",
+        distribution: "440412a823e55ea582c5b891bw4",
         languages: {
             "en":"English",
             "es-ES":"Spanish",
@@ -19,7 +19,7 @@ $.getScript('https://proxy-translator.app.crowdin.net/assets/proxy-translator.js
         },
         defaultLanguage: "en",
         defaultLanguageTitle: "English",
-        languageDetectType: "subdirectory",
+        languageDetectType: "default",
         poweredBy: false,
         position: "bottom-left",
         submenuPosition: "top-left",

--- a/dist/js/footer.js
+++ b/dist/js/footer.js
@@ -6,9 +6,9 @@ document.getElementById("footer-container").innerHTML = `
                         <div class="small m-0 text-white" id="copyright-text">Copyright &copy; LizardByte</div>
                     </div>
                     <div class="col-auto">
-                        <a class="link-light small" href="privacy.html">Privacy</a>
+                        <a class="link-light small" href="privacy">Privacy</a>
                         <span class="text-white mx-1">&middot;</span>
-                        <a class="link-light small" href="terms.html">Terms</a>
+                        <a class="link-light small" href="terms">Terms</a>
                     </div>
                 </div>
             </div>

--- a/dist/support.html
+++ b/dist/support.html
@@ -106,7 +106,7 @@
                                 </div>
                                 <div class="col-sm-auto border-white my-3 px-3 py-2 border-start">
                                     <a class="text-decoration-none link-light stretched-link"
-                                            href="/discord">
+                                            href="discord">
                                         <h4 class="card-title mb-3 fw-bolder">Discord</h4>
                                     </a>
                                     <p class="card-text">


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Several broken links found only on main home page, and only when accessed at `https://app.lizardbyte.dev` but not at `https://app.lizardbyte.dev/index.html`. Not much consistency with it. I believe the issue is with the subdirectory method of the crowdin js proxy translator. Using the default (query) method, may fix this. I tested locally and did not have the same issue.
- `/support` changed to `support`
- `terms.html` changed to `terms` (breaks local testing)
- `privacy.html` changed to `privacy` (breaks local testing)


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #60 


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
