### PR TITLE
fix(support): fix crowdin-ignore on alt text

### DIFF
--- a/dist/support.html
+++ b/dist/support.html
@@ -77,7 +77,7 @@
                                             <strong>Type:</strong> Documentation
                                         </small>
                                     </p>
-                                    <img class="m-3"
+                                    <img class="m-3 crowdin-ignore"
                                          alt="Read the docs"
                                          src="https://img.shields.io/static/v1?style=for-the-badge&label=Docs&message=Read&color=green&logo=readthedocs"
                                     >
@@ -201,8 +201,8 @@
                                         class="text-decoration-none"
                                         href="https://github.com/lizardbyte/sunshine/discussions"
                                         target="_blank">
-                                        <img class="m-3"
-                                             alt="Sunshine crowdin-ignore"
+                                        <img class="m-3 crowdin-ignore"
+                                             alt="Sunshine"
                                              src="https://img.shields.io/github/discussions/lizardbyte/sunshine?color=yellow&label=sunshine&style=for-the-badge&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAV+SURBVFhHrVd7iJVFFP+d795118c+fKSm0m4aIqlFGXt3Q1CzTFGpJClBUlFCCCuiP/qjksoygkgLE1dX0yXBddNIrDQhJLPwvYXko8RHPktcTXfveveb02/mm32Yu3bdvT+Y+82ceZzfnDnnzFxBBqDzEWjeuAIkg5hk1ymOXL0sZXtTvvuWaBcB5TydgBGoxyMIkMN2lqRQrwad2R6EGEqQhRp0wzbJxergM/zqp96E2yLgFBdjtPRGQgtwXk6hQrajwXc3QacipicxURXvIleGopeuD3LwkqzGOT+kCWkTMAn0wVDM1jEYIgWokknYJGI5tQ1zD7K1JxZJgLnaH2dpjQnBKlT77vShM1AUluOrcDuWmB3I9eK0ERZjsSmBhtNwQWdhoBenB1OOe8MvccDswrNedNvQUYiHCew2o0hiBn6wTuu7bg2zAmPDzTht9mOMF7UbmsBoUww1U6E6E1O9uG2YZZhA5deofKIXdQjWgWmFg+YxWmEmdnhx66ag2RN6B6rQD4uCB7DZizuG+QxOxbe4xrqi1DyH/lZ8EwGzHH00GxtQiPNBDd7x4g5De6OY0VBtg1ZCBKw/bOU3EGDcCstyKUI/ieEDGYOk7+o4AgynDf5ydeZI6hkSiVtAyzFFumOy5qKOqtd6cUagAQajhw9hOoSK9LPVJgIMjThZvcd0Ywf8GJTgStSTIQjuh0GOq1utyoP2VQdmqskSJ8s819znfjMEs40OF0MpLvKusMhiEdTaajMBYBa6sMLkzBR7JpJmBprEPIQ4yctqMOIUxKhDcdb2OQK6jKoFY+GMQgiHZwhmL4M5iRe4w5/YHOk2aRHgcPSJ8CA33sWxI+gLzkEyAa3HYuHFLOd4rMorvJuztkoDdtn+yAKCYfbbYt+l/tsh6H48L2fwtIYMv++Qz9COuThQHJQKnLRjGgn0tV8+MBoxkqYr9PV2gfPHm0v4BJfYSKGMlpjtHNyev2CdG0Q0HoH1S/g0af0wrnEscLJ2wBzAFE1hgxxHJ1U5LxtwiUrvRk8ur9xmgJV+aERAJF7nWvZtU+NqlsR0U405USs9mK+RHVbHFup1rJcjDDkeqVyWBVobvIp8DrBOLnyirWyOssgC2nDMfS1Os9AKFmS7jCRe1z3eQm1AKxEzu3nWfVAtdeFrcojr8jh59pVaaYoFpq9NcFz2ihi87ac5uCeZLkWRieEYzeTaLhu28AASOcSOpfTcrfgHx3EEoQ7nay8L9xlgHM/1GTrYQPzNwSdYuHMq/0XWYQWP9WPcSVl3uxBeDFbTL1ogUkiEy/EzGwnfjEjcxdI0IgJ3keIP9fIlLN6CNqedYrnsWpbwcdmKN/UEyiSf6XeAm/dNUIhJ8pab24Sm5XUFnuTEjb4ZwSZOy74HS6O7NsL6i1Vod+0VWzDbHZbvsUD/wKfSmUFXRJngKE1fGlQwGf8HzQR4FfMJ9gUFT3lRM6xye410YrH+YcO1lYuaa2yVjajSi/hIOqGrUx6TP4NAR8kqNPtZC9xgYFOBPObtLRSWeFFaUAmuShILtcL0IsGXJYfr8vg0hqNBgPFtKbe4gYCFWYOumpQPOX0Oz5hpo21wx7XUvka2F+zT32te4d+EIS7ceGy877cE2TpdytwhtYmbCFjoE4UF+viJAZrF7GXwKEcNIpnOtH49PfwMj2SPXMNOvhZVr8g0Kk64QLWhlsdQU7whtVgi6///UmudwAjkMxPOYxYbxMV/o/ILau/LJHK1wT0mH2IptaScYjqpdmfABSjnf8T3g8+jqzYdtEqgEaY0a5hqai4PYiKVFbkAsg5pldIptZt7Yuxk3yYqrpK1LvPfFm5JoCXMbO4zZSMaOVR4nRY6K+W4wAVsXLQTwL9Ig+ihduNjcQAAAABJRU5ErkJggg=="
                                         >
                                     </a>
@@ -210,8 +210,8 @@
                                         class="text-decoration-none"
                                         href="https://github.com/lizardbyte/themerr-jellyfin/discussions"
                                         target="_blank">
-                                        <img class="m-3"
-                                             alt="Themerr-jellyfin crowdin-ignore"
+                                        <img class="m-3 crowdin-ignore"
+                                             alt="Themerr-jellyfin"
                                              src="https://img.shields.io/github/discussions/lizardbyte/themerr-jellyfin?color=brightgreen&label=themerr-jellyfin&style=for-the-badge&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAADKAAAAygFrAxSyAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAArJJREFUSImt1U1oXUUYBuDn3uZi8GfR2LgQwRaLaRS6aVGhJaVuAhEUQ1CQWlwqdmcRFBR3LtzqStGim4IFiQaKUBe1/qAgWkVDrTVZaM0tCRgbm7T3zIyLnpv7c869acAXvsWcec/7znzzfTP0Q/KM4IKGFVe9J7m1L39TSPYJoobkqmRV8q+3Nysz0HMmMyGpiLTFI6XcP+2TTAnqat5xp8WNDVjqEie2flzHRU+LjomqEtY8a9Yeo5ag2mdv74oWugxeL/CiV0XVNs7dBhxuTl83SIZlpjQckFRAxd8yrwjk8YOtjneIz9ku2NnGacbW1jqT/aJpyZCIVTOSx1Vkos+kfGXJjIrUYbDFC0IhjQHTLVLwvWuSNckVyYpk2VP5zmoWRZckdc91iM+bNCe6IDkvOSeZNetnU+20qmCkcJjJGPjHbWJeSUGtLTXjovcFFUEmeEO0w6hR9zvRaRB9UWJwUFKz6t627yOSinnPSz4R3SK6Ipi0y4tGzStBxartMtOi3V1GJ0VJNJGP65Lzgv35uIHHjDhZJtwyaGLZTg27JS+L9pT0QGcER9znrX7inQZN/GVYclE0sF5BxThtl4OFqvrWIclLom2CjzQcLRrMGVSzItrSZwcLoo9F5/LbakgwIXqgi3esaLBgh2t+3zBFNxaXi3dRplHSPJuLVmoXi3fRXf4Q/bSBwIcYs2bIkkGZe0RHRPW8AAiSzGvFFMGvHpScEdV6mJyw15N5C7Zwyu2qDssMS2aM+6rcAH7xkORNYb1kUx7Nm/NH0RnB1+qOe0Iok+lt0MRZd2gYdNklN7lZ1aeivV09MeNhjxbK9oYMuvGlQ5IPShrvgHGfd9P7vWjlyHyDsnPZVkbv/aL1wpjfRGe7xJetOv3/GFQkwaTMKUEm+k4wYfL6G9yN/wCZz5LykptUmAAAAABJRU5ErkJggg=="
                                         >
                                     </a>
@@ -219,8 +219,8 @@
                                         class="text-decoration-none"
                                         href="https://github.com/lizardbyte/themerr-plex/discussions"
                                         target="_blank">
-                                        <img class="m-3"
-                                             alt="Themerr-plex crowdin-ignore"
+                                        <img class="m-3 crowdin-ignore"
+                                             alt="Themerr-plex"
                                              src="https://img.shields.io/github/discussions/lizardbyte/themerr-plex?color=brightgreen&label=themerr-plex&style=for-the-badge&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAADKAAAAygFrAxSyAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAArJJREFUSImt1U1oXUUYBuDn3uZi8GfR2LgQwRaLaRS6aVGhJaVuAhEUQ1CQWlwqdmcRFBR3LtzqStGim4IFiQaKUBe1/qAgWkVDrTVZaM0tCRgbm7T3zIyLnpv7c869acAXvsWcec/7znzzfTP0Q/KM4IKGFVe9J7m1L39TSPYJoobkqmRV8q+3Nysz0HMmMyGpiLTFI6XcP+2TTAnqat5xp8WNDVjqEie2flzHRU+LjomqEtY8a9Yeo5ag2mdv74oWugxeL/CiV0XVNs7dBhxuTl83SIZlpjQckFRAxd8yrwjk8YOtjneIz9ku2NnGacbW1jqT/aJpyZCIVTOSx1Vkos+kfGXJjIrUYbDFC0IhjQHTLVLwvWuSNckVyYpk2VP5zmoWRZckdc91iM+bNCe6IDkvOSeZNetnU+20qmCkcJjJGPjHbWJeSUGtLTXjovcFFUEmeEO0w6hR9zvRaRB9UWJwUFKz6t627yOSinnPSz4R3SK6Ipi0y4tGzStBxartMtOi3V1GJ0VJNJGP65Lzgv35uIHHjDhZJtwyaGLZTg27JS+L9pT0QGcER9znrX7inQZN/GVYclE0sF5BxThtl4OFqvrWIclLom2CjzQcLRrMGVSzItrSZwcLoo9F5/LbakgwIXqgi3esaLBgh2t+3zBFNxaXi3dRplHSPJuLVmoXi3fRXf4Q/bSBwIcYs2bIkkGZe0RHRPW8AAiSzGvFFMGvHpScEdV6mJyw15N5C7Zwyu2qDssMS2aM+6rcAH7xkORNYb1kUx7Nm/NH0RnB1+qOe0Iok+lt0MRZd2gYdNklN7lZ1aeivV09MeNhjxbK9oYMuvGlQ5IPShrvgHGfd9P7vWjlyHyDsnPZVkbv/aL1wpjfRGe7xJetOv3/GFQkwaTMKUEm+k4wYfL6G9yN/wCZz5LykptUmAAAAABJRU5ErkJggg=="
                                         >
                                     </a>


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
`crowdin-ignore` was accidentally added to alt text instead of class.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
