### PR TITLE
fix(projects): main urls should not use project base path

### DIFF
--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -36,6 +36,16 @@ on:
         required: false
         default: 'master'
         type: string
+      base_url:
+        description: |
+          Base URL of the site. With default option, the root will come from LizardByte.github.io (app.lizardbyte.dev).
+          This is useful to re-use the theme config and many assets from that site; but requires you to prefix other
+          assets with `/<RepoName>` (e.g. `/MyRepo/assets/img/my-image.png`).
+
+          If this is set to `_auto`, the workflow will determine this value automatically.
+        required: false
+        default: ''
+        type: string
     secrets:
       GH_BOT_EMAIL:
         description: 'Email address of the bot account'
@@ -173,7 +183,11 @@ jobs:
         run: |
           config_file="_config_ci.yml"
           echo "---" > $config_file
-          echo "baseurl: ${{ steps.configure-pages.outputs.base_path }}" >> $config_file
+          if [ "${{ inputs.base_url }}" == '_auto' ]; then
+            echo "baseurl: '${{ steps.configure-pages.outputs.base_path }}'" >> $config_file
+          else
+            echo "baseurl: '${{ inputs.base_url }}'" >> $config_file
+          fi
 
           cat $config_file
 
@@ -186,6 +200,7 @@ jobs:
           # if inputs.config_file exists
           config_files="_config_ci.yml,_config_theme.yml"
           if [ -e "${{ inputs.config_file }}" ]; then
+            cat ${{ inputs.config_file }}
             config_files="${config_files},${{ inputs.config_file }}"
           fi
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Some subproject URLs are re-written incorrectly.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
