### PR TITLE
fix(deploy): ensure large sites can be deployed

### DIFF
--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -101,7 +101,7 @@ jobs:
               tar -xf ${{ inputs.extract_archive }} -C .
               ;;
             *.zip)
-              unzip ${{ inputs.extract_archive }} -d .
+              7z x ${{ inputs.extract_archive }} -o.
               ;;
             *)
               echo "Unsupported archive format"
@@ -206,11 +206,16 @@ jobs:
 
           bundle exec jekyll build --future --config ${config_files}
 
+      - name: Prepare Artifacts  # uploading artifacts may fail if not zipped due to very large quantity of files
+        shell: bash
+        run: |
+          7z a _site.zip ./_site/*
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: site
-          path: _site
+          path: _site.zip
           if-no-files-found: error
           include-hidden-files: true
           retention-days: 1
@@ -244,8 +249,11 @@ jobs:
           name: site
           path: gh-pages
 
-      - name: no-jekyll
+      - name: Setup gh-pages
+        working-directory: gh-pages
         run: |
+          7z x _site.zip -o.
+          rm _site.zip
           touch gh-pages/.nojekyll
 
       - name: Deploy to gh-pages


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Large sites such as GameDB cannot deploy because there are too many files to upload to artifacts. Therefore we need to archive all the files before uploading, then extract them in the download step.

Additionally, extracting artifacts will now be done with 7z.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
