### PR TITLE
fix(gamepad-tester): warn Firefox users about Switch mapping bug

### DIFF
--- a/_sass/styles.scss
+++ b/_sass/styles.scss
@@ -739,6 +739,21 @@ table tr:nth-child(2n) {
   padding: 0.8rem;
 }
 
+.gamepad-browser-warning {
+  margin-inline: auto;
+  max-width: 46rem;
+}
+
+.gamepad-browser-warning[hidden] {
+  display: none;
+}
+
+.gamepad-browser-warning a {
+  font-weight: 600;
+  overflow-wrap: anywhere;
+  text-decoration: underline;
+}
+
 .gamepad-device-details > summary {
   align-items: center;
   cursor: pointer;
@@ -845,6 +860,12 @@ table tr:nth-child(2n) {
     margin: 0 !important;
     max-width: none;
     padding: 0.65rem 0.85rem;
+  }
+
+  .gamepad-tester.has-gamepad .gamepad-browser-warning {
+    margin-top: 0.75rem !important;
+    max-width: none;
+    padding: 0.55rem 0.75rem;
   }
 
   .gamepad-tester.has-gamepad .gamepad-selector-panel {

--- a/assets/js/gamepad-tester.js
+++ b/assets/js/gamepad-tester.js
@@ -5,6 +5,13 @@ function createDPadButtonVisuals(shapes) {
     }));
 }
 
+const FIREFOX_SWITCH_GAMEPAD_FIXED_VERSION = 155;
+
+function getFirefoxMajorVersion(userAgent) {
+    const match = /\bFirefox\/(\d+)/.exec(userAgent);
+    return match ? Number.parseInt(match[1], 10) : null;
+}
+
 document.addEventListener('DOMContentLoaded', function() {
     const gamepadHelper = new GamepadHelper()
     const gamepadHelperVersion = globalThis.gamepadHelperVersion;
@@ -17,6 +24,8 @@ document.addEventListener('DOMContentLoaded', function() {
     const gamepadTester = document.getElementById('GamepadTester');
     const gamepadStatus = document.getElementById('gamepad-status');
     const gamepadStatusMessage = document.getElementById('gamepad-status-message');
+    const firefoxSwitchWarning = document.getElementById('firefox-switch-warning');
+    const firefoxMajorVersion = getFirefoxMajorVersion(navigator.userAgent);
     let gamepadVisualButtons = new Map();
     let gamepadVisualSticks = [];
     let gamepadVisualTriggers = new Map();
@@ -205,7 +214,15 @@ document.addEventListener('DOMContentLoaded', function() {
 
         const gamepadIndices = Object.keys(gamepads);
         const hasGamepads = gamepadIndices.length > 0;
+        const hasNintendoSwitchController = Object.values(gamepads).some(gamepad =>
+            gamepadHelper.detectControllerType(gamepad.id) === gamepadHelper.CONTROLLER_TYPES.SWITCH
+        );
         gamepadTester.classList.toggle('has-gamepad', hasGamepads);
+        firefoxSwitchWarning.hidden = !(
+            firefoxMajorVersion !== null
+            && firefoxMajorVersion < FIREFOX_SWITCH_GAMEPAD_FIXED_VERSION
+            && hasNintendoSwitchController
+        );
 
         if (hasGamepads) {
             gamepadSelectorContainer.style.removeProperty('display');

--- a/gamepad-tester.html
+++ b/gamepad-tester.html
@@ -36,6 +36,15 @@ js:
             </p>
         </header>
 
+        <div id="firefox-switch-warning" class="gamepad-browser-warning gamepad-inline-notice mt-3" aria-live="polite" hidden>
+            <i class="fas fa-triangle-exclamation mt-1" aria-hidden="true"></i>
+            <span>
+                Firefox versions before 155 can report incorrect buttons and axes for Nintendo Switch controllers.
+                Update to Firefox 155 or later, or use another current browser.
+                Details: <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1704419" target="_blank" rel="noopener noreferrer">https://bugzilla.mozilla.org/show_bug.cgi?id=1704419</a>
+            </span>
+        </div>
+
         <section class="gamepad-selector-panel mt-4" id="gamepad-selector-container" style="display: none;" aria-labelledby="gamepad-selector-heading">
             <div class="gamepad-selector-heading">
                 <div>


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
Add a Nintendo Switch controller warning in the gamepad tester for Firefox versions earlier than 155, based on parsed browser major version and detected controller type. The warning links to Mozilla bug 1704419 and is shown/hidden dynamically as gamepads connect. Styling updates were added to keep the notice centered by default and compact within the active tester layout.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
